### PR TITLE
Swap out labelmod for debugoose

### DIFF
--- a/data.json
+++ b/data.json
@@ -37,15 +37,15 @@
       "resourcehub": "https://desktopgooseunofficial.github.io/ResourceHub/mods/GooseManager.html"
     },
     "label-mod": {
-      "name": "Label Mod",
-      "name-internal": "label-mod",
+      "name": "Debugoose",
+      "name-internal": "debugoose",
       "level": 0,
       "category": "default",
-      "description": "Info about your goose",
+      "description": "Debugging tool. See Console.Writeln()'s",
       "goose-version": "0.3",
-      "mod-version": "1.2",
-      "url": "https://github.com/CodeF53/Goose_LabelMod/releases/download/v1.2/ShowTask.dll", 
-      "resourcehub": "insert link to mod in resource hub here"
+      "mod-version": "1.0",
+      "url": "https://github.com/CodeF53/DskptGoose-Debugoose/releases/download/v1.0/debugoose.dll", 
+      "resourcehub": "https://github.com/CodeF53/DskptGoose-Debugoose/blob/master/readme.md"
     },
     "goose-lua": {
       "name": "GooseLua",


### PR DESCRIPTION
I have abandoned labelmod, as I am an idiot that likes to change names of projects alot
debugoose is labelmod but updated (and actually good for debugging)